### PR TITLE
Add command line argument for phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,14 @@ If you are still stuck don't worry! Check out THIRD API CALL in SampleConsoleApp
 
 ## Conclusion
 You are now able to build a universal translator to get any language in and back out in your rest client of choice. If you are using my sample app you now have a console app and an example on how you can bring AI into you C# code! 
+
+## Running the Program with a Command Line Argument
+The program now accepts a command line argument for the phrase to be translated. If no command line argument is provided, the program will use a default phrase.
+
+### Example Command
+```bash
+dotnet run --project SampleConsoleApp "Your phrase to be translated"
+```
+
+### Default Phrase
+If no command line argument is provided, the program will use the default phrase: "Boutons et voyants du panneau de commande\n".

--- a/SampleConsoleApp/Program.cs
+++ b/SampleConsoleApp/Program.cs
@@ -15,7 +15,7 @@ class Program
     static readonly HttpClient client3 = new();
     static IConfiguration? Configuration { get; set; }
 
-    static async Task Main()
+    static async Task Main(string[] args)
     {
         var builder = new ConfigurationBuilder()
             .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
@@ -26,9 +26,12 @@ class Program
         // Add headers
         client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", Configuration["Ocp-Apim-Subscription-Key"]);
         client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Region", Configuration["Ocp-Apim-Subscription-Region"]);
+
+        // Determine the phrase to be translated
+        string phrase = args.Length > 0 ? args[0] : "Boutons et voyants du panneau de commande\n";
+
         // Create body
-        // Change me to ask a new question!
-        var body = new[] { new { Text = "Boutons et voyants du panneau de commande\n" } };
+        var body = new[] { new { Text = phrase } };
         var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
 
         // FIRST API CALL


### PR DESCRIPTION
Fixes #5

Update the program to accept a command line argument for the phrase to be translated.

* **SampleConsoleApp/Program.cs**
  - Modify the `Main` method to accept a command line argument.
  - Determine the phrase to be translated based on the command line argument or use a default phrase.
  - Update the `body` variable to use the phrase from the command line argument or default phrase.

* **README.md**
  - Add instructions on how to run the program with a command line argument.
  - Update the example command to include a phrase as a command line argument.
  - Explain that the program will use a default phrase if no command line argument is provided.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AzureCloudWorkshops/ACW-GenAI-UniversalTranslator/issues/5?shareId=78c3d9b1-077c-4c10-80a0-e6b3fd5e05c3).